### PR TITLE
Support multiple contents in sampling results

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <System9Version>9.0.5</System9Version>
     <System10Version>10.0.0-preview.4.25258.110</System10Version>
-    <MicrosoftExtensionsAIVersion>9.8.0</MicrosoftExtensionsAIVersion>
+    <MicrosoftExtensionsAIVersion>9.9.0</MicrosoftExtensionsAIVersion>
   </PropertyGroup>
 
   <!-- Product dependencies netstandard -->
@@ -53,7 +53,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.8.0-preview.1.25412.6" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.9.0-preview.1.25458.4" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(System9Version)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(System9Version)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(System9Version)" />

--- a/src/ModelContextProtocol.Core/Client/McpClient.Methods.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClient.Methods.cs
@@ -623,7 +623,7 @@ public abstract partial class McpClient : McpSession, IMcpClient
 
         return new()
         {
-            Content = content ?? new TextContentBlock { Text = lastMessage?.Text ?? string.Empty },
+            Contents = [content ?? new TextContentBlock { Text = lastMessage?.Text ?? string.Empty }],
             Model = chatResponse.ModelId ?? "unknown",
             Role = lastMessage?.Role == ChatRole.User ? Role.User : Role.Assistant,
             StopReason = chatResponse.FinishReason == ChatFinishReason.Length ? "maxTokens" : "endTurn",

--- a/src/ModelContextProtocol.Core/Client/McpClientExtensions.cs
+++ b/src/ModelContextProtocol.Core/Client/McpClientExtensions.cs
@@ -703,7 +703,7 @@ public static class McpClientExtensions
 
         return new()
         {
-            Content = content ?? new TextContentBlock { Text = lastMessage?.Text ?? string.Empty },
+            Contents = [content ?? new TextContentBlock { Text = lastMessage?.Text ?? string.Empty }],
             Model = chatResponse.ModelId ?? "unknown",
             Role = lastMessage?.Role == ChatRole.User ? Role.User : Role.Assistant,
             StopReason = chatResponse.FinishReason == ChatFinishReason.Length ? "maxTokens" : "endTurn",

--- a/src/ModelContextProtocol.Core/McpJsonUtilities.McpJsonConverter.cs
+++ b/src/ModelContextProtocol.Core/McpJsonUtilities.McpJsonConverter.cs
@@ -1,0 +1,91 @@
+﻿using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+
+namespace ModelContextProtocol;
+
+public static partial class McpJsonUtilities
+{
+    [ThreadStatic]
+    private static McpSession? t_currentMcpSession;
+
+    /// <summary>
+    /// Serializes the given value to a <see cref="JsonNode"/> using the provided <see cref="JsonTypeInfo{T}"/>,
+    /// </summary>
+    internal static JsonNode? SerializeContextual<T>(T? value, JsonTypeInfo<T> typeInfo, McpSession session)
+    {
+        if (session is null)
+        {
+            Throw.IfNull(session);
+        }
+
+        if (t_currentMcpSession is not null)
+        {
+            throw new InvalidOperationException("Reentrant call to McpJsonUtilities.SerializeContextual detected.");
+        }
+
+        t_currentMcpSession = session;
+        try
+        {
+            return JsonSerializer.SerializeToNode(value!, typeInfo);
+        }
+        finally
+        {
+            t_currentMcpSession = null;
+        }
+    }
+
+    /// <summary>
+    /// Deserializes the given value to a <see cref="JsonNode"/> using the provided <see cref="JsonTypeInfo{T}"/>,
+    /// </summary>
+    internal static T? DeserializeContextual<T>(JsonNode? node, JsonTypeInfo<T> typeInfo, McpSession session)
+    {
+        if (session is null)
+        {
+            Throw.IfNull(session);
+        }
+
+        if (t_currentMcpSession is not null)
+        {
+            throw new InvalidOperationException("Reentrant call to McpJsonUtilities.DeserializeContextual detected.");
+        }
+
+        t_currentMcpSession = session;
+        try
+        {
+            return JsonSerializer.Deserialize(node, typeInfo);
+        }
+        finally
+        {
+            t_currentMcpSession = null;
+        }
+    }
+
+    /// <summary>
+    /// Defines an abstract JSON converter that has access to the current <see cref="IMcpEndpoint"/> context during serialization and deserialization.
+    /// </summary>
+    /// <typeparam name="T">The type being converted.</typeparam>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public abstract class McpContextualJsonConverter<T> : JsonConverter<T>
+    {
+        /// <summary>
+        /// Reads the JSON representation of the value.
+        /// </summary>
+        public abstract T? Read(ref Utf8JsonReader reader, McpSession? session, JsonSerializerOptions options);
+
+        /// <summary>
+        /// Writes the JSON representation of the value.
+        /// </summary>
+        public abstract void Write(Utf8JsonWriter writer, T value, McpSession? session, JsonSerializerOptions options);
+
+        /// <inheritdoc/>
+        public sealed override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            Read(ref reader, t_currentMcpSession, options);
+
+        /// <inheritdoc/>
+        public sealed override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
+            Write(writer, value, t_currentMcpSession, options);
+    }
+}

--- a/tests/Common/Utils/TestServerTransport.cs
+++ b/tests/Common/Utils/TestServerTransport.cs
@@ -74,7 +74,7 @@ public class TestServerTransport : ITransport
         await WriteMessageAsync(new JsonRpcResponse
         {
             Id = request.Id,
-            Result = JsonSerializer.SerializeToNode(new CreateMessageResult { Content = new TextContentBlock { Text = "" }, Model = "model", Role = Role.User }, McpJsonUtilities.DefaultOptions),
+            Result = JsonSerializer.SerializeToNode(new CreateMessageResult { Contents = [new TextContentBlock { Text = "" }], Model = "model", Role = Role.User }, McpJsonUtilities.DefaultOptions),
         }, cancellationToken);
     }
 

--- a/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/HttpServerIntegrationTests.cs
@@ -260,7 +260,7 @@ public abstract class HttpServerIntegrationTests : LoggedTest, IClassFixture<Sse
             {
                 Model = "test-model",
                 Role = Role.Assistant,
-                Content = new TextContentBlock { Text = "Test response" },
+                Contents = [new TextContentBlock { Text = "Test response" }],
             };
         };
         await using var client = await GetClientAsync(options);

--- a/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
+++ b/tests/ModelContextProtocol.AspNetCore.Tests/MapMcpTests.cs
@@ -179,7 +179,7 @@ public abstract class MapMcpTests(ITestOutputHelper testOutputHelper) : KestrelI
                         {
                             Model = "test-model",
                             Role = Role.Assistant,
-                            Content = new TextContentBlock { Text = "Sampling response from client" },
+                            Contents = [new TextContentBlock { Text = "Sampling response from client" }],
                         };
                     },
                 },

--- a/tests/ModelContextProtocol.Tests/Client/McpClientCreationTests.cs
+++ b/tests/ModelContextProtocol.Tests/Client/McpClientCreationTests.cs
@@ -68,10 +68,10 @@ public class McpClientCreationTests
                     SamplingHandler = async (c, p, t) =>
                         new CreateMessageResult 
                         { 
-                            Content = new TextContentBlock { Text = "result" }, 
-                            Model = "test-model", 
-                            Role = Role.User, 
-                            StopReason = "endTurn" 
+                            Contents = [new TextContentBlock { Text = "result" }],
+                            Model = "test-model",
+                            Role = Role.User,
+                            StopReason = "endTurn"
                         },
                 },
                 Roots = new RootsCapability

--- a/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
+++ b/tests/ModelContextProtocol.Tests/ClientIntegrationTests.cs
@@ -385,7 +385,7 @@ public partial class ClientIntegrationTests : LoggedTest, IClassFixture<ClientIn
                         {
                             Model = "test-model",
                             Role = Role.Assistant,
-                            Content = new TextContentBlock { Text = "Test response" },
+                            Contents = [new TextContentBlock { Text = "Test response" }],
                         };
                     },
                 },

--- a/tests/ModelContextProtocol.Tests/DockerEverythingServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/DockerEverythingServerTests.cs
@@ -83,7 +83,7 @@ public class DockerEverythingServerTests(ITestOutputHelper testOutputHelper) : L
                         {
                             Model = "test-model",
                             Role = Role.Assistant,
-                            Content = new TextContentBlock { Text = "Test response" },
+                            Contents = [new TextContentBlock { Text = "Test response" }],
                         };
                     },
                 },

--- a/tests/ModelContextProtocol.Tests/Server/McpServerExtensionsTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerExtensionsTests.cs
@@ -76,7 +76,7 @@ public class McpServerExtensionsTests
 
         var resultPayload = new CreateMessageResult
         {
-            Content = new TextContentBlock { Text = "resp" },
+            Contents = [new TextContentBlock { Text = "resp" }],
             Model = "test-model",
             Role = Role.Assistant,
             StopReason = "endTurn",
@@ -113,7 +113,7 @@ public class McpServerExtensionsTests
 
         var resultPayload = new CreateMessageResult
         {
-            Content = new TextContentBlock { Text = "resp" },
+            Contents = [new TextContentBlock { Text = "resp" }],
             Model = "test-model",
             Role = Role.Assistant,
             StopReason = "endTurn",

--- a/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
+++ b/tests/ModelContextProtocol.Tests/Server/McpServerTests.cs
@@ -668,7 +668,7 @@ public class McpServerTests : LoggedTest
 
             CreateMessageResult result = new()
             {
-                Content = new TextContentBlock { Text = "The Eiffel Tower." },
+                Contents = [new TextContentBlock { Text = "The Eiffel Tower." }],
                 Model = "amazingmodel",
                 Role = Role.Assistant,
                 StopReason = "endTurn",


### PR DESCRIPTION
This PR showcases how we could account for potential future breaking changes in the MCP protocol. It changes the model and introduces a converter that dynamically changes its schema based on the negotiated protocol version.